### PR TITLE
Add support for multiple connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ automation:
       data:
         serial: "YOUR_SERIAL_NUMBER"  # Replace with your charging station serial
         mode: "NORMAL"  # You can adjust the mode based on your integration's needs
+        connector: 1    # Connector number
         limit: "{{ states('input_number.smappee_charging_speed') | int }}"
 ```
 Also, you need your serial number for the charger to make the service calls, wasn't able to find this in the api but you can find it in the Smappee app.

--- a/custom_components/smappee_charging_profiles/__init__.py
+++ b/custom_components/smappee_charging_profiles/__init__.py
@@ -29,13 +29,14 @@ async def async_setup_entry(hass: HomeAssistant, entry):
         serial = call.data.get("serial")
         mode = call.data.get("mode")
         limit = call.data.get("limit", 0)
+        connector = call.data.get("connector", 1)
 
-        _LOGGER.debug(f"Setting charging mode for serial {serial} to {mode} with limit {limit}.")
+        _LOGGER.debug(f"Setting charging mode for serial {serial} to {mode} with limit {limit} on connector {connector}.")
         
         api_client = hass.data[DOMAIN][entry.entry_id]
     
         try:
-            await api_client.set_charging_mode(serial, mode, limit)
+            await api_client.set_charging_mode(serial, mode, limit, connector)
             _LOGGER.debug(f"Charging mode set successfully for {serial}")
         except Exception as e:
             _LOGGER.error(f"Failed to set charging mode for {serial}: {e}")

--- a/custom_components/smappee_charging_profiles/api_client.py
+++ b/custom_components/smappee_charging_profiles/api_client.py
@@ -9,21 +9,20 @@ class SmappeeApiClient:
         self.oauth_client = oauth_client
         self.base_url = "https://app1pub.smappee.net/dev/v3"
 
-    async def set_charging_mode(self, serial, mode, limit):
+    async def set_charging_mode(self, serial, mode, limit, connector):
         """Set the charging mode for the given serial number and connector."""
         # Ensure token is refreshed if needed
         await self.oauth_client.ensure_token_valid()
-
-        url = f"{self.base_url}/chargingstations/{serial}/connectors/1/mode"
-        headers = {
-            "Authorization": f"Bearer {self.oauth_client.access_token}",
-            "Content-Type": "application/json",
-        }
 
         limitPercentage = True if mode == "NORMAL_PERCENTAGE" else False
         if limitPercentage:
             mode = "NORMAL"
 
+        url = f"{self.base_url}/chargingstations/{serial}/connectors/{connector}/mode"
+        headers = {
+            "Authorization": f"Bearer {self.oauth_client.access_token}",
+            "Content-Type": "application/json",
+        }
 
         # Create the base payload with the mode
         payload = {"mode": mode}

--- a/custom_components/smappee_charging_profiles/services.yaml
+++ b/custom_components/smappee_charging_profiles/services.yaml
@@ -7,6 +7,9 @@ set_charging_mode:
     mode:
       description: "Charging mode to set (NORMAL, NORMAL_PERCENTAGE, SMART, PAUSED)"
       example: "NORMAL"
+    connector:
+      description: "Connector number of charging station when there are multiple"
+    example: 1
     limit:
       description: "Current limit in amperes"
       example: 10


### PR DESCRIPTION
This PR allows specifying different connectors within the call.
To maintain backwards compatibility with charging stations which only have one connector, the default fallback connector is 1 when the connector is not specified.